### PR TITLE
Fix resolver.js example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Configure Jest to use your own `resolver.js` file:
 Configure your `resolver.js` file:
 
 ```js
-module.exports = require("jest-enhanced-resolve")({
+module.exports = require("jest-enhanced-resolve").default({
   mainFields: ["source", "module", "main"],
 })
 ```


### PR DESCRIPTION
The example must call `require("...").default(...)` instead of `require("...")(...)` otherwise an error is thrown:

```
TypeError: require(...) is not a function
```